### PR TITLE
(TK-146) Add generate-ssl-context function

### DIFF
--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -619,12 +619,11 @@
       (is (instance? SSLContext result)))))
 
 (deftest generate-ssl-context-test
-  (let [base-path   "test-resources/puppetlabs/ssl_utils/examples/ssl/"
-        ssl-context (SSLContext/getDefault)
-        ssl-cert    (str base-path "certs/localhost.pem")
-        ssl-key     (str base-path "private_keys/localhost.pem")
-        ssl-ca-cert (str base-path "certs/ca.pem")
-        ssl-ca-crls (str base-path "ca_crl.pem")
+  (let [ssl-context (SSLContext/getDefault)
+        ssl-cert    (open-ssl-file "certs/localhost.pem")
+        ssl-key     (open-ssl-file "private_keys/localhost.pem")
+        ssl-ca-cert (open-ssl-file "certs/ca.pem")
+        ssl-ca-crls (open-ssl-file "ca_crl.pem")
         ssl-opts    {:ssl-context ssl-context
                      :ssl-cert    ssl-cert
                      :ssl-key     ssl-key

--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -618,6 +618,44 @@
                    (open-ssl-file "ca_crl.pem"))]
       (is (instance? SSLContext result)))))
 
+(deftest generate-ssl-context-test
+  (let [base-path   "test-resources/puppetlabs/ssl_utils/examples/ssl/"
+        ssl-context (SSLContext/getDefault)
+        ssl-cert    (str base-path "certs/localhost.pem")
+        ssl-key     (str base-path "private_keys/localhost.pem")
+        ssl-ca-cert (str base-path "certs/ca.pem")
+        ssl-ca-crls (str base-path "ca_crl.pem")
+        ssl-opts    {:ssl-context ssl-context
+                     :ssl-cert    ssl-cert
+                     :ssl-key     ssl-key
+                     :ssl-ca-cert ssl-ca-cert
+                     :ssl-ca-crls ssl-ca-crls}]
+    (testing "providing an ssl-context option returns the provided SSLContext"
+      (let [result (generate-ssl-context ssl-opts)]
+        (is (= ssl-context result))))
+
+    (testing "providing :ssl-key, :ssl-cert, and :ssl-ca-cert will cause an SSLContext
+              to be configured from PEMs"
+      (let [result (generate-ssl-context (dissoc ssl-opts :ssl-context :ssl-ca-crls))]
+        (is (instance? SSLContext result))))
+
+    (testing "providing :ssl-ca-cert and :ssl-ca-crls will cause an SSLContext to be configured
+              from CA Cert and crl PEMs"
+      (let [result (generate-ssl-context (dissoc ssl-opts :ssl-context :ssl-key))]
+        (is (instance? SSLContext result))))
+
+    (testing "providing :ssl-ca-cert will cause an SSLContext to be configured from CA cert PEM"
+      (let [result (generate-ssl-context (dissoc ssl-opts :ssl-context :ssl-key :ssl-ca-crls))]
+        (is (instance? SSLContext result))))
+
+    (testing "providing no SSL options will result in no SSLContext being returned"
+      (let [result (generate-ssl-context {})]
+        (is (nil? result))))
+
+    (testing "providing an incomplete SSL configuration will cause an exception to be thrown"
+      (is (thrown? IllegalArgumentException
+                   (generate-ssl-context (dissoc ssl-opts :ssl-context :ssl-ca-cert)))))))
+
 (let [keypair (generate-key-pair 512)
       public (get-public-key keypair)
       private (get-private-key keypair)]


### PR DESCRIPTION
Add generate-ssl-context function, which, when given a map of
options, either configures an SSLContext, returns nil if no
SSL options were provided, or throws an exception if an incomplete
SSL configuration was provided.