### PR TITLE
(Server-816) Display unknown extensions as Base64

### DIFF
--- a/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
@@ -43,6 +43,8 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import java.io.EOFException;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.security.PublicKey;
 import java.security.cert.CRLException;
@@ -852,19 +854,9 @@ public class ExtensionsUtils {
      * @param ip IP address encoded in an octet string.
      * @return A string representing the given IP address.
      */
-    public static String octetStringToIpString(ASN1OctetString ip) {
-        StringBuilder str = new StringBuilder();
-
-        byte[] octets = ip.getOctets();
-        for (int i=0; i < octets.length; i++) {
-            int byteVal = (octets[i] >= 0) ? octets[i] : (octets[i] + 256);
-            str.append(Integer.toString(byteVal));
-            if (i != (octets.length - 1)) {
-                str.append(".");
-            }
-        }
-
-        return str.toString();
+    public static String octetStringToIpString(ASN1OctetString ip)
+            throws UnknownHostException {
+        return InetAddress.getByAddress(ip.getOctets()).toString().split("/")[1];
     }
 
     /**

--- a/test/puppetlabs/ssl_utils/extensions_utils_test.clj
+++ b/test/puppetlabs/ssl_utils/extensions_utils_test.clj
@@ -2,9 +2,14 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.ssl-utils.simple-test :as simple-test]
             [puppetlabs.ssl-utils.core :as ssl-utils]
-            [puppetlabs.ssl-utils.simple :as simple]))
+            [puppetlabs.ssl-utils.simple :as simple])
+  (:import (java.net InetAddress)))
 
 (deftest general-names
+  (testing "InetAddress.toString() returns proper string form."
+    (let [addr (InetAddress/getByAddress (byte-array [192 168 2 1]))]
+      (= "/192.168.2.1" (.toString addr))))
+
   (testing "Can encode and decode all General Names types"
     (let [gns {:rfc822-name ["foo@bar.com"]
                :dns-name ["localhost.localdomain"]

--- a/test/puppetlabs/ssl_utils/extensions_utils_test.clj
+++ b/test/puppetlabs/ssl_utils/extensions_utils_test.clj
@@ -1,0 +1,23 @@
+(ns puppetlabs.ssl-utils.extensions-utils-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.ssl-utils.simple-test :as simple-test]
+            [puppetlabs.ssl-utils.core :as ssl-utils]
+            [puppetlabs.ssl-utils.simple :as simple]))
+
+(deftest general-names
+  (testing "Can encode and decode all General Names types"
+    (let [gns {:rfc822-name ["foo@bar.com"]
+               :dns-name ["localhost.localdomain"]
+               :uri ["file:///foo/bar"]
+               :ip ["192.168.69.90"]
+               :registered-id ["1.2.3.4"]}
+          in-exts [{:oid ssl-utils/subject-alt-name-oid
+                    :critical true
+                    :value gns}]
+          opts {:extensions in-exts
+                :keylength 512}
+          ssl-cert (simple/gen-self-signed-cert "test" 42 opts)
+          cert (simple-test/roundtrip-pem
+                 ssl-utils/cert->pem! ssl-utils/pem->cert (:cert ssl-cert))
+          out-exts (ssl-utils/get-extensions cert)]
+      (is (= in-exts out-exts)))))


### PR DESCRIPTION
This PR does two things. 
 
1. There was a bug when attempting to decode some a `General Name` values, specifically in the case where an IP address or an OID. Previously an exception was being thrown. Now they are properly decoded.

2. Now unknown values are returned as Base64-encoded strings, preceded by `base64:` instead of byte arrays. Base64-encoded data is much easier to print to the screen and examine.