### PR TITLE
(MAINT) Handle getCommonName for X500Name with no CN

### DIFF
--- a/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
@@ -7,6 +7,8 @@ import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
+import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -130,10 +132,18 @@ public class SSLUtils {
      * Given an X500Name, return the common name from it.
      *
      * @param x500Name The X500 name string to extract from
-     * @return The common name from the X500Name
+     * @return The common name from the X500Name.  Empty string if none available.
      */
     public static String getCommonNameFromX500Name(String x500Name) {
-        return new X500Name(x500Name).getRDNs(BCStyle.CN)[0].getFirst().getValue().toString();
+        RDN[] rdns = new X500Name(x500Name).getRDNs(BCStyle.CN);
+        String commonName = "";
+        if (rdns.length > 0) {
+            AttributeTypeAndValue attributeInfo = rdns[0].getFirst();
+            if (attributeInfo != null) {
+                commonName = attributeInfo.getValue().toString();
+            }
+        }
+        return commonName;
     }
 
     /**

--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -763,8 +763,10 @@
       (is (false? (issued-by? crl "issuer")))))
 
   (deftest x500-name->CN-test
-    (testing "getting CN from DN works"
-      (is (= "subject" (x500-name->CN subject))))))
+    (testing "get proper CN from DN when CN available"
+      (is (= "subject" (x500-name->CN subject))))
+    (testing "get empty string for CN when no CN in DN"
+      (is (= "" (x500-name->CN (dn [:l "Nowheresville"])))))))
 
 (deftest extensions
   (testing "Found all extensions from a certificate on disk."


### PR DESCRIPTION
Previously, if `getCommonNameFromX500Name` were called with an x500Name
that had no CN attribute within it, an `ArrayIndexOutOfBoundsException`
would be thrown.  With changes in this commit, the method would instead
return an empty string for this case.