### PR TITLE
(SERVER-1545) Add helpers for getting subject from a certificate

### DIFF
--- a/src/clojure/puppetlabs/ssl_utils/core.clj
+++ b/src/clojure/puppetlabs/ssl_utils/core.clj
@@ -7,7 +7,8 @@
            (org.bouncycastle.pkcs PKCS10CertificationRequest)
            (com.puppetlabs.ssl_utils SSLUtils
                                      ExtensionsUtils)
-           (java.util Map List Date Set))
+           (java.util Map List Date Set)
+           (org.bouncycastle.asn1.x500.style BCStyle))
   (:require [clojure.tools.logging :as log]
             [clojure.walk :as walk]
             [clojure.string :as string]
@@ -22,7 +23,7 @@
   ;; TODO: Maybe using a string parsing algo is faster?
   [x]
   (try
-    (X500Name. x)
+    (X500Name. BCStyle/INSTANCE x)
     (not (nil? x))
     (catch Exception _
       false)))
@@ -939,6 +940,13 @@
    :post [(string? %)]}
   (-> (.getSubjectX500Principal x509-certificate)
       get-cn-from-x500-principal))
+
+(defn get-subject-from-x509-certificate
+  "Given an X509Certificate object, retrieve its subject."
+  [x509-certificate]
+  {:pre [(certificate? x509-certificate)]
+   :post [(string? %)]}
+  (SSLUtils/getSubjectFromX509Certificate x509-certificate))
 
 (defn get-public-key
   "Given an object which contains a public key, extract the public key


### PR DESCRIPTION
This commit adds new helpers --
get-subject-from-x509-certificate in Clojure /
SSLUtils.getSubjectFromX509Certificate() in Java -- for extracting the
full subject from an X509Certificate object.  The helpers return the
subject in BCStyle since each of the related helpers already in
jvm-ssl-utils also use BCStyle.

This commit also changes each of the related helpers which implicitly
use BCStyle, by virtue of it being the default style, to explicitly use
BCStyle.  This is done to protect against the possibility of a future
default style change in BouncyCastle causing some of the helpers to
mangle string values if differing styles are used among helpers to
encode vs. decode values.