### PR TITLE
(PE-18417) Update to bouncycastle 1.55

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
   :pedantic? :abort
 
   :dependencies [[org.clojure/tools.logging "0.2.6" :exclusions [org.clojure/clojure]]
-                 [org.bouncycastle/bcpkix-jdk15on "1.50"]
+                 [org.bouncycastle/bcpkix-jdk15on "1.55"]
                  [commons-codec "1.9"]
                  [clj-time "0.7.0"]
                  [puppetlabs/i18n "0.4.3"]]


### PR DESCRIPTION
The version of bouncycastle we are shipping is over 2 years old.
We've had a user report incompatibilities between it and recent
certificates generated by external tools.

This commit updates us to the most recent version, which contains
many bug fixes and features compared to the older version we were
shipping, but should be backward-compatible.