### PR TITLE
(SERVER-1315) Use key pair file when extracting ca-cert

### DIFF
--- a/src/clojure/puppetlabs/ssl_utils/core.clj
+++ b/src/clojure/puppetlabs/ssl_utils/core.clj
@@ -575,13 +575,13 @@
     (SSLUtils/pemToCerts r)))
 
 (schema/defn ^:always-validate pem->ca-cert :- X509Certificate
-  "Given a CA certificate chain and public key, extract the first certificate and
-  verify that it matches the given public key."
+  "Given a CA certificate chain and key pair, extract the first certificate and
+  verify that it matches the key pair."
   [cert-chain-pem :- Readerable
-   pubkey-pem :- Readerable]
+   keypair-pem :- Readerable]
   (with-open [cert-chain-pem-reader (reader cert-chain-pem)
-              pubkey-pem-reader (reader pubkey-pem)]
-    (SSLUtils/pemToCaCert cert-chain-pem-reader pubkey-pem-reader)))
+              keypair-pem-reader (reader keypair-pem)]
+    (SSLUtils/pemToCaCert cert-chain-pem-reader keypair-pem-reader)))
 
 (schema/defn ^:always-validate pem->cert :- X509Certificate
   "Given the path to a PEM file (or some other object supported by clojure's `reader`),

--- a/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
@@ -513,13 +513,13 @@ public class SSLUtils {
      * extract the first certificate and verify that it matches the given public key.
      *
      * @param certChainReader Reader for a PEM-encoded stream of X.509 certificates
-     * @param pubKeyReader Reader for a PEM-encoded public key
+     * @param keyPairReader Reader for a PEM-encoded key pair
      * @return The first decoded certificate in the certificate stream
      * @throws CertificateException
      * @throws IOException
-     * @throws IllegalArgumentException if the cert chain is empty or the first cert doesn't match the public key
+     * @throws IllegalArgumentException if the cert chain is empty or the first cert doesn't match the public key in the key pair
      */
-    public static X509Certificate pemToCaCert(Reader certChainReader, Reader pubKeyReader)
+    public static X509Certificate pemToCaCert(Reader certChainReader, Reader keyPairReader)
         throws CertificateException, IOException
     {
         List<X509Certificate> certs = pemToCerts(certChainReader);
@@ -527,7 +527,7 @@ public class SSLUtils {
             throw new IllegalArgumentException("The certificate PEM stream must contain at least 1 certificate");
 
         X509Certificate caCert = certs.get(0);
-        PublicKey caPubkey = pemToPublicKey(pubKeyReader);
+        PublicKey caPubkey = pemToKeyPair(keyPairReader).getPublic();
         if(!certMatchesPubKey(caCert, caPubkey)) {
             throw new IllegalArgumentException("The first certificate in the certificate chain does not match the expected public key");
         }
@@ -573,6 +573,24 @@ public class SSLUtils {
             return new JcaPEMKeyConverter().getKeyPair((PEMKeyPair) obj).getPrivate();
         else
             throw new IllegalArgumentException("Expected a KeyPair or PrivateKey, got " + obj);
+    }
+
+    /**
+     * Decodes the provided object (read from a PEM stream via {@link #pemToObjects}) into a key pair.
+     *
+     * @param obj The object to decode into a PrivateKey
+     * @return The KeyPair decoded from the object
+     * @throws PEMException
+     * @see #pemToKeyPair
+     * @see #pemToKeyPairs
+     */
+    public static KeyPair objectToKeyPair(Object obj)
+        throws PEMException
+    {
+        if (obj instanceof PEMKeyPair)
+            return new JcaPEMKeyConverter().getKeyPair((PEMKeyPair) obj);
+        else
+            throw new IllegalArgumentException("Expected a KeyPair, got " + obj);
     }
 
     /**
@@ -632,6 +650,43 @@ public class SSLUtils {
             throw new IllegalArgumentException("The PEM stream must contain exactly one public key");
         JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
         return converter.getPublicKey((SubjectPublicKeyInfo) objects.get(0));
+    }
+
+    /**
+     * Given a PEM reader, decode the contents into a list of key pairs.
+     * @param reader Reader for a PEM-encoded stream
+     * @return The list of decoded key pairs from the stream
+     * @throws IOException
+     * @throws PEMException
+     * @see #pemToKeyPair
+     */
+    public static List<KeyPair> pemToKeyPairs(Reader reader)
+        throws IOException
+    {
+        List<Object> objects = pemToObjects(reader);
+        List<KeyPair> results = new ArrayList<KeyPair>(objects.size());
+        for (Object o : objects)
+            results.add(objectToKeyPair(o));
+        return results;
+    }
+
+    /**
+     * Given a PEM reader, decode the contents into a key pair.
+     * Throws an exception if multiple key pairs are found.
+     *
+     * @param reader Reader for a PEM-encoded stream
+     * @return The decoded key pair from the stream
+     * @throws IOException
+     * @throws IllegalArgumentException
+     * @see #pemToKeyPairs
+     */
+    public static KeyPair pemToKeyPair(Reader reader)
+        throws IOException
+    {
+        List<KeyPair> keyPairs = pemToKeyPairs(reader);
+        if (keyPairs.size() != 1)
+            throw new IllegalArgumentException("The PEM stream must contain exactly one key pair");
+        return keyPairs.get(0);
     }
 
     /**

--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -401,27 +401,27 @@
   (testing "read CA certificate from PEM stream"
     (testing "with an empty reader"
       (let [bundle-pem (StringReader. "")
-            pubkey-pem (open-ssl-file "public_keys/localhost.pem")]
+            keypair-pem (open-ssl-file "ca/ca_key.pem")]
         (is (thrown-with-msg? IllegalArgumentException
                               #"The certificate PEM stream must contain at least 1 certificate"
-                              (pem->ca-cert bundle-pem pubkey-pem)))))
+                              (pem->ca-cert bundle-pem keypair-pem)))))
 
     (testing "with a single certificate that matches the public key"
       (let [bundle-pem (open-ssl-file "certs/ca.pem")
-            pubkey-pem (open-ssl-file "ca/ca_pub.pem")]
-        (is (certificate? (pem->ca-cert bundle-pem pubkey-pem)))))
+            keypair-pem (open-ssl-file "ca/ca_key.pem")]
+        (is (certificate? (pem->ca-cert bundle-pem keypair-pem)))))
 
     (testing "with a certificate chain whose first cert matches the public key"
       (let [bundle-pem (open-ssl-file "certs/multiple.pem")
-            pubkey-pem (open-ssl-file "ca/ca_pub.pem")]
-        (is (certificate? (pem->ca-cert bundle-pem pubkey-pem)))))
+            keypair-pem (open-ssl-file "ca/ca_key.pem")]
+        (is (certificate? (pem->ca-cert bundle-pem keypair-pem)))))
 
     (testing "with a single certificate that doesn't match the public key"
       (let [bundle-pem (open-ssl-file "certs/ca.pem")
-            pubkey-pem (open-ssl-file "public_keys/localhost.pem")]
+            keypair-pem (open-ssl-file "private_keys/localhost.pem")]
         (is (thrown-with-msg? IllegalArgumentException
                               #"The first certificate in the certificate chain does not match the expected public key"
-                              (pem->ca-cert bundle-pem pubkey-pem))))))
+                              (pem->ca-cert bundle-pem keypair-pem))))))
 
 
   (testing "write certificate to PEM stream"


### PR DESCRIPTION
The initial approach for extracting and verifying the CA certificate
used a single public key; unfortunately this doesn't mesh with what
Puppetserver expects. Changes made in SERVER-86 specifically tested that
certificate signing could happen without a ca public key. Since the
private keys we generate contain both the public and private key, we can
extract the public key from that pair and use that comparison. Switching
from a standalone public key to a private key with associated public key
should be more correct as we're doing comparisons with the content we'll
actually be using for signing.