### PR TITLE
(maint) Relax schema constraints on generate-ssl-context

### DIFF
--- a/src/clojure/puppetlabs/ssl_utils/core.clj
+++ b/src/clojure/puppetlabs/ssl_utils/core.clj
@@ -139,7 +139,8 @@
    (schema/optional-key :ssl-key) Readerable
    (schema/optional-key :ssl-ca-cert) Readerable
    (schema/optional-key :ssl-ca-crls) Readerable
-   (schema/optional-key :ssl-context) SSLContext})
+   (schema/optional-key :ssl-context) SSLContext
+   schema/Any schema/Any})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Internal


### PR DESCRIPTION
The addition of schemas in this library made the arguments acceptable
to `generate-ssl-context` too restrictive for the way the library was
typcially used. This commit relaxes the requirements of the
`SSLContextOptions` schema to improve backwards compatability.