### PR TITLE
(SERVER-2205) Changes to support multiple CRLs; (maint) target 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: clojure
 lein: 2.7.1
 jdk:
-  - oraclejdk7
-  - openjdk7
   - oraclejdk8
 script: ./ext/travisci/test.sh
 sudo: false

--- a/project.clj
+++ b/project.clj
@@ -5,14 +5,14 @@
     :password :env/clojars_jenkins_password
     :sign-releases false })
 
-(defproject puppetlabs/ssl-utils "0.9.2-SNAPSHOT"
+(defproject puppetlabs/ssl-utils "1.0.0-SNAPSHOT"
   :url "http://www.github.com/puppetlabs/jvm-ssl-utils"
 
   :description "SSL certificate management on the JVM."
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.6.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.5"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -20,7 +20,7 @@
   :pedantic? :abort
 
   :dependencies [[org.clojure/tools.logging]
-                 [org.bouncycastle/bcpkix-jdk15on "1.55"]
+                 [org.bouncycastle/bcpkix-jdk15on "1.59"]
                  [commons-codec]
                  [clj-time]
                  [puppetlabs/i18n]


### PR DESCRIPTION
The work that instigated the PR is in 545d071, the majority of the code changes and the reasons for them are within that commit message (pasted below).

It also updates our version of bouncycastle and clj-parent. This does not pull in the Java 9 compatibility changes in clj-parent, though it upgrades past the point where compatibility of Java 7 was assured. It also fixes existing deprecation warnings. Happy to pull those out into a separate PR, but figured it was good to update while I was here.

```
This commit adds a general `objs->pem!` similar to the more specific
{crl,cert}->pem! functions so we may efficiently serialize chain/bundles
of PKI objects.

It also adds a pem->ca-crl to provide an analog to pem->ca-cert though
its usage in puppetserver does not allow us to require the ca cert to do
the degree of validation that pem->ca-cert does.

It pulls most of the `create-ca-extensions` from puppetserver
into this library to ease testing (creating chained CAs and their CRLs).

Finally, it modifies the existing "simple" namespace's gen-cert* and the
functions that call it to allow creating ca certs.

The last two changes, create-ca-extensions & gen-cert* are meant to aid
later integration tests by consumers of this library.

```