### PR TITLE
(SERVER-2440) fix primitive type name in Reader-/Writerable schemas

### DIFF
--- a/src/clojure/puppetlabs/ssl_utils/core.clj
+++ b/src/clojure/puppetlabs/ssl_utils/core.clj
@@ -128,11 +128,11 @@
 
 (def Readerable
   "Schema for anything that can be handed off to clojure's reader function."
-  (schema/cond-pre Reader BufferedReader InputStream File URI URL Socket byte[] char[] String))
+  (schema/cond-pre Reader BufferedReader InputStream File URI URL Socket bytes chars String))
 
 (def Writerable
   "Schema for anything that can be handed off to clojure's writer function."
-  (schema/cond-pre Writer BufferedWriter OutputStream File URI URL Socket byte[] char[] String))
+  (schema/cond-pre Writer BufferedWriter OutputStream File URI URL Socket bytes chars String))
 
 (def SSLContextOptions
   "Schema for the options map that generate-ssl-context requires."

--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -13,7 +13,8 @@
   (:require [clojure.test :refer :all]
             [clojure.java.io :refer [resource reader]]
             [puppetlabs.ssl-utils.core :refer :all]
-            [puppetlabs.ssl-utils.simple :as simple]))
+            [puppetlabs.ssl-utils.simple :as simple]
+            [schema.core :as schema]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utilities
@@ -89,6 +90,11 @@
   (-> (DateTime/now)
       (.plus (Period/years 5))
       (.toDate)))
+
+(defn str->bytes
+  "Turn a `String s` into `bytes[]`"
+  [^String s]
+  (bytes (byte-array (map (comp byte int) s))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests
@@ -981,3 +987,18 @@
                                             (cn "subject")
                                             [(subject-alt-names {:dns-name ["moe"] :ip ["192.168.69.90" "192.168.69.91" "192.168.69.92"]} false)])]
       (is (= #{"192.168.69.90" "192.168.69.91" "192.168.69.92"} (set (get-subject-ip-alt-names csr)))))))
+
+(deftest schema-test
+  (testing "readerable"
+    (is (schema/validate Readerable (char-array "somestring"))
+        "A char array satisfies Readerable")
+
+    (is (schema/validate Readerable (str->bytes "someotherstring"))
+        "A byte array satisfies Readerable"))
+
+  (testing "writerable"
+    (is (schema/validate Writerable (char-array "somestring"))
+        "A char array satisfies Writerable")
+
+    (is (schema/validate Writerable (str->bytes "someotherstring"))
+        "A byte array satisfies Writerable")))


### PR DESCRIPTION
Simon (reporter in https://tickets.puppetlabs.com/browse/SERVER-2440) correctly points out that `bytes[]` is parsed as two separate tokens, `bytes` (which is a function in `clojure.core`) and `[]`, an empty vector.

Since schema adds primitives we can use the shorthands `bytes` and `chars` in the schemas.

Also added basic tests that ensures that byte and char arrays both satisfy `Readerable` and `Writerable`.