### PR TITLE
(PDB-4357) FIPS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,20 @@
 language: clojure
 lein: 2.9.1
-jdk:
-  - openjdk8
-  - openjdk11
+jobs:
+  include:
+    - stage: jdk8 without FIPS
+      script: lein with-profile dev test
+      jdk: openjdk8
+    - stage: jdk8 with FIPS
+      script: lein with-profile fips test
+      jdk: openjdk8
+
+    - stage: jdk11 without FIPS
+      script: lein with-profile dev test
+      jdk: openjdk11
+    - stage: jdk11 with FIPS
+      script: lein with-profile fips test
+      jdk: openjdk11
+sudo: false
 notifications:
   email: false
-

--- a/project.clj
+++ b/project.clj
@@ -52,7 +52,7 @@
                            :jar-exclusions ^:replace []
                            :source-paths ^:replace ["src/clojure" "src/java"]}}
 
-  :plugins [[lein-parent "0.3.5"]
+  :plugins [[lein-parent "0.3.7"]
             [puppetlabs/i18n "0.8.0"]]
   :lein-release {:scm         :git
                  :deploy-via  :lein-deploy}

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.5"]
+  :parent-project {:coords [puppetlabs/clj-parent "3.0.0"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -20,7 +20,6 @@
   :pedantic? :abort
 
   :dependencies [[org.clojure/tools.logging]
-                 [org.bouncycastle/bcpkix-jdk15on "1.60"]
                  [commons-codec]
                  [clj-time]
                  [puppetlabs/i18n]
@@ -35,18 +34,30 @@
   ;; depend on this source jar using a :classifier in their :dependencies.
   :classifiers [["sources" :sources-jar]]
 
-  :profiles {:dev {:dependencies [[org.clojure/clojure]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure]
+                                  [org.bouncycastle/bcpkix-jdk15on]]
+                   :resource-paths ["test-resources"]}
+
+             ;; per https://github.com/technomancy/leiningen/issues/1907
+             ;; the provided profile is necessary for lein jar / lein install
+             :provided {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]
+                        :resource-paths ["test-resources"]}
+
+             :fips {:dependencies [[org.clojure/clojure]
+                                   [org.bouncycastle/bcpkix-fips]
+                                   [org.bouncycastle/bc-fips]]
                    :resource-paths ["test-resources"]}
 
              :sources-jar {:java-source-paths ^:replace []
                            :jar-exclusions ^:replace []
                            :source-paths ^:replace ["src/clojure" "src/java"]}}
 
-  :plugins [[lein-parent "0.3.1"]
+  :plugins [[lein-parent "0.3.5"]
             [puppetlabs/i18n "0.8.0"]]
   :lein-release {:scm         :git
                  :deploy-via  :lein-deploy}
   :deploy-repositories [["releases" ~(deploy-info "https://clojars.org/repo")]
                         ["snapshots" ~(deploy-info "https://clojars.org/repo")]]
 
-  )
+  :repositories [["puppet-releases" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-releases__local/"]
+                 ["puppet-snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-snapshots__local/"]])

--- a/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
@@ -15,6 +15,7 @@ import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERUTF8String;
 import org.bouncycastle.asn1.misc.MiscObjectIdentifiers;
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.Attribute;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
@@ -722,7 +723,7 @@ public class ExtensionsUtils {
                 SubjectPublicKeyInfo.getInstance(publicKey.getEncoded());
 
         DigestCalculator digCalc = new JcaDigestCalculatorProviderBuilder().build()
-                .get(new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1));
+                .get(new AlgorithmIdentifier(NISTObjectIdentifiers.id_sha256));
 
         X509ExtensionUtils utils = new X509ExtensionUtils(digCalc);
         return utils.createSubjectKeyIdentifier(pubKeyInfo);
@@ -740,7 +741,7 @@ public class ExtensionsUtils {
 
             DigestCalculator digCalc =
                     new JcaDigestCalculatorProviderBuilder().build().get(
-                            new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1));
+                            new AlgorithmIdentifier(NISTObjectIdentifiers.id_sha256));
 
             X509ExtensionUtils utils = new X509ExtensionUtils(digCalc);
             authorityKeyId = utils.createAuthorityKeyIdentifier(authPubKeyInfo);

--- a/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
@@ -37,7 +37,7 @@ import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509ExtensionUtils;
 import org.bouncycastle.operator.DigestCalculator;
 import org.bouncycastle.operator.OperatorCreationException;
-import org.bouncycastle.operator.bc.BcDigestCalculatorProvider;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import java.io.EOFException;
@@ -721,8 +721,8 @@ public class ExtensionsUtils {
         SubjectPublicKeyInfo pubKeyInfo =
                 SubjectPublicKeyInfo.getInstance(publicKey.getEncoded());
 
-        DigestCalculator digCalc =
-                new BcDigestCalculatorProvider().get(new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1));
+        DigestCalculator digCalc = new JcaDigestCalculatorProviderBuilder().build()
+                .get(new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1));
 
         X509ExtensionUtils utils = new X509ExtensionUtils(digCalc);
         return utils.createSubjectKeyIdentifier(pubKeyInfo);
@@ -739,7 +739,7 @@ public class ExtensionsUtils {
                             pubKey.getEncoded());
 
             DigestCalculator digCalc =
-                    new BcDigestCalculatorProvider().get(
+                    new JcaDigestCalculatorProviderBuilder().build().get(
                             new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1));
 
             X509ExtensionUtils utils = new X509ExtensionUtils(digCalc);

--- a/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
@@ -168,7 +168,7 @@ public class SSLUtils {
         }
 
         return requestBuilder.build(
-                new JcaContentSignerBuilder("SHA1withRSA").
+                new JcaContentSignerBuilder("SHA256withRSA").
                         build(keyPair.getPrivate()));
     }
 

--- a/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
@@ -26,18 +26,12 @@ import org.bouncycastle.cert.jcajce.JcaX509CRLConverter;
 import org.bouncycastle.cert.jcajce.JcaX509CRLHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v2CRLBuilder;
-import org.bouncycastle.crypto.util.PrivateKeyFactory;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMException;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
-import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
-import org.bouncycastle.operator.OperatorCreationException;
-import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder;
+import org.bouncycastle.operator.*;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
@@ -55,22 +49,11 @@ import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
 
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.KeyManagementException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.SignatureException;
-import java.security.UnrecoverableKeyException;
+import java.security.*;
 import java.security.cert.CRLException;
 import java.security.cert.CertStore;
 import java.security.cert.CertificateException;
@@ -91,11 +74,23 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class SSLUtils {
-
     /**
      * The default key length to use when generating a keypair.
      */
     public static final int DEFAULT_KEY_LENGTH = 4096;
+
+    public static Class getProviderClass() throws ClassNotFoundException {
+        Class clazz;
+        try {
+            clazz = Class.forName("org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider");
+        } catch(ClassNotFoundException cnf) {
+            // if FIPS isn't present, attempt to use the non-FIPS provider. If this fails,
+            // the exception is allow to propagate
+            clazz = Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider");
+        }
+
+        return clazz;
+    }
 
     /**
      * Create new public & private keys with length 4096.
@@ -234,10 +229,9 @@ public class SSLUtils {
         AlgorithmIdentifier digAlgId =
                 new DefaultDigestAlgorithmIdentifierFinder().find(sigAlgId);
 
-        ContentSigner signer =
-                new BcRSAContentSignerBuilder(sigAlgId, digAlgId).build(
-                        PrivateKeyFactory.createKey(issuerPrivateKey.getEncoded()));
+        JcaContentSignerBuilder builder = new JcaContentSignerBuilder("SHA256withRSA");
 
+        ContentSigner signer = builder.build(issuerPrivateKey);
 
         JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
 
@@ -1190,9 +1184,32 @@ public class SSLUtils {
         // Implementation references:
         //  http://www.bouncycastle.org/wiki/display/JA1/BC+Version+2+APIs#BCVersion2APIs-VerifyingaSignature
         //  http://stackoverflow.com/questions/3711754/why-java-security-nosuchproviderexception-no-such-provider-bc
-        JcaContentVerifierProviderBuilder builder =
-            new JcaContentVerifierProviderBuilder().setProvider(new BouncyCastleProvider());
-        return csr.isSignatureValid(builder.build(csr.getSubjectPublicKeyInfo()));
+        JcaContentVerifierProviderBuilder builder;
+        try {
+            Class<?> providerClass = getProviderClass();
+            Constructor<?> ctor = providerClass.getConstructor();
+            builder = new JcaContentVerifierProviderBuilder().setProvider((Provider)ctor.newInstance());
+        } catch(ClassNotFoundException | NoSuchMethodException | InstantiationException |
+                IllegalAccessException | InvocationTargetException ex) {
+            throw new OperatorCreationException("unable to find suitable provider!", ex);
+        }
+        try {
+            return csr.isSignatureValid(builder.build(csr.getSubjectPublicKeyInfo()));
+        } catch(RuntimeOperatorException roe) {
+            // in bc-fips, a bad signature generates an exception that isn't generated in the
+            // non-FIPS version.
+            // specifically:
+            // org.bouncycastle.operator.RuntimeOperatorException: exception obtaining signature:
+            // org.bouncycastle.crypto.InvalidSignatureException: Unable to process signature: block incorrect
+            // Caused by: java.security.SignatureException: org.bouncycastle.crypto.InvalidSignatureException: Unable to
+            // process signature: block incorrect
+            Throwable cause = roe.getCause();
+            if(cause != null && cause.getClass().isAssignableFrom(SignatureException.class)) {
+                return false;
+            } else {
+                throw roe;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Move the bouncycastle jar to the dev profile. This will allow us
to specify the bouncycastle jars on the classpath at runtime like
we do for logging configuration. At installation time, we can install
the FIPS-compliant version of the jars, or the standard versions.

The FIPS version of the jar has a reduced number of classes compared to
the standard provider, but all the base functionality is there. Reworked
SSLUtils and ExtensionsUtils to use the classes that are provided in
both versions, and determine which provider based on availability on the
classpath.

Added additional build stages to Travis CI so that we test FIPS and
non-FIPS on both JDK 8 and JDK 11.