### PR TITLE
(SERVER-2801) Use extension processing method directly

### DIFF
--- a/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
@@ -355,12 +355,7 @@ public class ExtensionsUtils {
             ASN1Set extsAsn1 = attr.getAttrValues();
             if (extsAsn1 != null) {
                 ASN1Encodable extObj = extsAsn1.getObjectAt(0);
-
-                if (extObj instanceof Extensions) {
-                    return (Extensions)extObj;
-                } else if (extObj instanceof DERSequence) {
-                    return Extensions.getInstance(extObj);
-                }
+                return Extensions.getInstance(extObj);
             }
         }
 


### PR DESCRIPTION
The type checking when getting extensions out of a CSR is more
restrictive than in bouncy caste's own functions. This commit updates us
to use their `getInstance` method for extensions, which is less brittle.
Our type checking breaks when updating to BC 1.63, which switched from
using DER types to using DL types when parsing pretty much everywhere.