### PR TITLE
(SERVER-2801) Catch IOException for malformed Netscape comment ext

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   { :url url
     :username :env/clojars_jenkins_username
     :password :env/clojars_jenkins_password
-    :sign-releases false })
+    :sign-releases false})
 
 (defproject puppetlabs/ssl-utils "3.0.5-SNAPSHOT"
   :url "http://www.github.com/puppetlabs/jvm-ssl-utils"

--- a/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
@@ -542,7 +542,7 @@ public class ExtensionsUtils {
         } else if (oid.equals(MiscObjectIdentifiers.netscapeCertComment)) {
             try {
                 return ASN1Primitive.fromByteArray(data);
-            } catch (EOFException e) {
+            } catch (IOException e) {
                 // Sometimes the comment field is not properly wrapped in an IA5String
                 return new DERIA5String(new String(data, Charset.forName("US-ASCII")));
             }


### PR DESCRIPTION
This commit updates the exception we catch when parsing an unwrapped
Netscape comment cert extension from a legacy Puppet cert. Newer
versions of Bouncy Castle added an extra error case when attempting to
parse extension byte arrays, that our legacy certs hit, because the
extension values are not byte arrays but unwrapped strings. Previously,
we would hit an EOFException, but now it throws a generic IOException
before proceeding to the check we used to fail. IOException is a
superclass of EOFException, so by catching the former, we are also
backwards compatible.