### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: clojure
-dist: xenial
-#lein: 2.9.1
 install:
        - sudo env LEIN_ROOT=true curl -L -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/2.9.1/bin/lein
        - sudo chmod a+x  /usr/local/bin/lein
@@ -25,20 +23,12 @@ jobs:
       script: lein with-profile dev test
       jdk: openjdk8
       arch: ppc64le
-    - stage: jdk8 with FIPS
-      before_install: sudo apt-get install openjdk-8-jdk
-      script:  lein with-profile fips test
-      jdk: openjdk8
-      arch: ppc64le
 
     - stage: jdk11 without FIPS
       script:  lein with-profile dev test
       jdk: openjdk11
       arch: ppc64le
-    - stage: jdk11 with FIPS
-      script:  lein with-profile fips test
-      jdk: openjdk11
-      arch: ppc64le
+
 sudo: false
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: clojure
-lein: 2.9.1
+dist: xenial
+#lein: 2.9.1
+install:
+       - sudo env LEIN_ROOT=true curl -L -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/2.9.1/bin/lein
+       - sudo chmod a+x  /usr/local/bin/lein
+       - lein self-install
 jobs:
   include:
     - stage: jdk8 without FIPS
@@ -15,6 +20,25 @@ jobs:
     - stage: jdk11 with FIPS
       script: lein with-profile fips test
       jdk: openjdk11
+
+    - stage: jdk8 without FIPS
+      script: lein with-profile dev test
+      jdk: openjdk8
+      arch: ppc64le
+    - stage: jdk8 with FIPS
+      before_install: sudo apt-get install openjdk-8-jdk
+      script:  lein with-profile fips test
+      jdk: openjdk8
+      arch: ppc64le
+
+    - stage: jdk11 without FIPS
+      script:  lein with-profile dev test
+      jdk: openjdk11
+      arch: ppc64le
+    - stage: jdk11 with FIPS
+      script:  lein with-profile fips test
+      jdk: openjdk11
+      arch: ppc64le
 sudo: false
 notifications:
   email: false


### PR DESCRIPTION
Adding power support for this package to support arch independent

I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.

This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model.

Please help to verify and merge.