### PR TITLE
(SERVER-2550) Add functions to identify delta CRLs

### DIFF
--- a/src/clojure/puppetlabs/ssl_utils/core.clj
+++ b/src/clojure/puppetlabs/ssl_utils/core.clj
@@ -206,6 +206,10 @@
   "SubjectAlternativeName OID 2.5.29.17"
   ExtensionsUtils/SUBJECT_ALTERNATIVE_NAME_OID)
 
+(def delta-crl-indicator-oid
+  "DeltaCRLIndicator OID 2.5.29.27"
+  ExtensionsUtils/DELTA_CRL_INDICATOR_OID)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Extensions
 
@@ -403,6 +407,10 @@
   {:oid "1.3.6.1.4.1.34380.1.1.4"
    :critical (boolean critical)
    :value key})
+
+(schema/defn ^:always-validate delta-crl? :- schema/Bool
+  [crl :- X509CRL]
+  (boolean (get-extension-value crl delta-crl-indicator-oid)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Core

--- a/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
@@ -82,6 +82,12 @@ public class ExtensionsUtils {
         Extension.subjectAlternativeName.toString();
 
     /**
+     * DeltaCRLIndicator OID 2.5.29.27
+     */
+    public static final String DELTA_CRL_INDICATOR_OID =
+        Extension.deltaCRLIndicator.toString();
+
+    /**
      * Return true if the given OID is contained within the subtree of parent OID.
      *
      * @param parentOid The OID of the parent tree.

--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -496,7 +496,7 @@
         (is (not (revoked? crl cert)))
         (is (not (revoked? crl cert2)))
         (let [updated-crl (revoke-multiple crl private-key public-key serials)]
-          (testing "certificates are reovked"
+          (testing "certificates are revoked"
             (is (revoked? updated-crl cert))
             (is (revoked? updated-crl cert2))))))))
 


### PR DESCRIPTION
This commit adds functions to determine whether a given CRL is a delta CRL or
not. We do not support delta CRLs (which contain only changes since the base CRL
was published, rather than the whole list of revoked certs), so this will allow
us to error cleanly if we encounter a delta CRL, particularly when consuming CRL
updates from an external CA.