### PR TITLE
(SERVER-2550) Add `get-crl-number` function

### DIFF
--- a/src/clojure/puppetlabs/ssl_utils/core.clj
+++ b/src/clojure/puppetlabs/ssl_utils/core.clj
@@ -376,6 +376,12 @@
    :critical false
    :value (biginteger number)})
 
+(schema/defn ^:always-validate get-crl-number :- (schema/maybe BigInteger)
+  "Given a CRL, return the value of the CRL Number extension, or nil if the
+  extension is not present."
+  [crl :- X509CRL]
+  (get-extension-value crl crl-number-oid))
+
 (schema/defn ^:always-validate puppet-node-uid :- SSLExtension
   "Create a `Puppet Node UID` extension."
   [uid :- schema/Str

--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -468,7 +468,7 @@
 
     (testing "revoking a certificate"
       (let [cert (-> "certs/cert_with_exts.pem" open-ssl-file pem->cert)]
-        (is (= 0 (get-extension-value crl crl-number-oid)))
+        (is (= 0 (get-crl-number crl)))
         (is (false? (revoked? crl cert)))
 
         ;; We need to advance the value of DateTime.now() so it's not the
@@ -481,7 +481,7 @@
           (testing "certificate is revoked"
             (is (true? (revoked? updated-crl cert))))
           (testing "CRLNumber extension value is incremented"
-            (is (= 1 (get-extension-value updated-crl crl-number-oid))))
+            (is (= 1 (get-crl-number updated-crl))))
           (testing "dates are advanced"
             (is (.after (.getThisUpdate updated-crl) (.getThisUpdate crl)))
             (is (.after (.getNextUpdate updated-crl) (.getNextUpdate crl))))

--- a/test/puppetlabs/ssl_utils/testutils.clj
+++ b/test/puppetlabs/ssl_utils/testutils.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.ssl-utils.testutils
   (:import (java.io ByteArrayOutputStream ByteArrayInputStream)
            (java.security.cert X509Certificate)
-           (java.security MessageDigest)
+           (java.security MessageDigest PublicKey)
            (javax.security.auth.x500 X500Principal)
            (org.bouncycastle.asn1.x500 X500Name)
            (org.bouncycastle.pkcs PKCS10CertificationRequest)
@@ -19,7 +19,8 @@
   {:pre [(public-key? pub-key)]
    :post [(vector? %)
           (every? integer? %)]}
-  (let [bytes   (-> pub-key
+  (let [bytes   (-> ^PublicKey
+                    pub-key
                     .getEncoded
                     SubjectPublicKeyInfo/getInstance
                     .getPublicKeyData
@@ -47,7 +48,7 @@
 
 (defmethod has-subject? [X509Certificate String]
   [cert x500-name]
-  (= x500-name (-> cert .getSubjectX500Principal .getName)))
+  (= x500-name (-> ^X509Certificate cert .getSubjectX500Principal .getName)))
 
 (defmethod has-subject? [X509Certificate X500Name]
   [cert x500-name]


### PR DESCRIPTION
This PR adds a function to get the value of the CRL Number extension from a
given CRL. This value is used to determine how new the CRL is (compared to other
CRLs issued by the same cert).

Also fixes a couple `illegal reflective access` warning.