### PR TITLE
(SERVER-2550) Add testutil for generating multiple CRLs

### DIFF
--- a/test/puppetlabs/ssl_utils/testutils.clj
+++ b/test/puppetlabs/ssl_utils/testutils.clj
@@ -146,6 +146,12 @@
         private-key (get-private-key random-keys)]
     (SSLUtils/generateCRL issuer private-key public-key)))
 
+(defn generate-multiple-crls
+  [issuer issuer-private-key issuer-public-key]
+  {:original (generate-crl issuer issuer-private-key issuer-public-key)
+   :new (generate-newer-crl issuer issuer-private-key issuer-public-key)
+   :newest (generate-newest-crl issuer issuer-private-key issuer-public-key)})
+
 (defn generate-ca-cert
   [issuer-name issuer-key-pair serial root?]
   (let [subject-name (if root?


### PR DESCRIPTION
This commit adds a test utility for generating multiple CRLs for a given issuer.
This can be used with `generate-cert-chain-with-crls` to generate a cert chain
where each cert has issued multiple CRLs. This will facilitate testing CRL
updates, ensuring that the appropriate CRL is used in various situations.