### PR TITLE
Use java.specification.version for version check

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
                     ;; this only ensures that we run with the proper profiles
                     ;; during testing. This JVM opt will be set in the puppet module
                     ;; that sets up the JVM classpaths during installation.
-                    :jvm-opts ~(let [version (System/getProperty "java.version")
+                    :jvm-opts ~(let [version (System/getProperty "java.specification.version")
                                      [major minor _] (clojure.string/split version #"\.")
                                      unsupported-ex (ex-info "Unsupported major Java version. Expects 8 or 11."
                                                       {:major major


### PR DESCRIPTION
java.version on some platforms differs from what Puppetserver's project file tries to parse.
java.specification.version is however guaranteed to match the expected format.

See https://github.com/puppetlabs/puppetserver/pull/2539 for the same fix.