### PR TITLE
(maint) Allow CA extensions to include auth key id from issuer public key

### DIFF
--- a/src/clojure/puppetlabs/ssl_utils/core.clj
+++ b/src/clojure/puppetlabs/ssl_utils/core.clj
@@ -361,17 +361,27 @@
 
 (schema/defn create-ca-extensions :- (schema/pred extension-list?)
   "Create a list of extensions to be added to the CA certificate."
-  [ca-name :- (schema/pred valid-x500-name?)
-   ca-serial :- (schema/pred number?)
-   ca-public-key :- (schema/pred public-key?)]
-  [(authority-key-identifier
-     ca-name ca-serial false)
-   (basic-constraints-for-ca)
-   (key-usage
+  ([issuer-public-key :- (schema/pred public-key?)
+    ca-public-key :- (schema/pred public-key?)]
+   [(authority-key-identifier
+     issuer-public-key false)
+    (basic-constraints-for-ca)
+    (key-usage
      #{:key-cert-sign
        :crl-sign} true)
-   (subject-key-identifier
+    (subject-key-identifier
      ca-public-key false)])
+  ([ca-name :- (schema/pred valid-x500-name?)
+    ca-serial :- (schema/pred number?)
+    ca-public-key :- (schema/pred public-key?)]
+   [(authority-key-identifier
+     ca-name ca-serial false)
+    (basic-constraints-for-ca)
+    (key-usage
+     #{:key-cert-sign
+       :crl-sign} true)
+    (subject-key-identifier
+     ca-public-key false)]))
 
 (schema/defn ^:always-validate crl-number :- SSLExtension
   "Create a `CRL Number` extension"

--- a/test/puppetlabs/ssl_utils/core_test.clj
+++ b/test/puppetlabs/ssl_utils/core_test.clj
@@ -298,6 +298,32 @@
                                            sign-exts)
             actual-ext   (get-extension cert-w-exts
                                         "2.5.29.19")]
+        (is (= actual-ext expected-ext))))
+
+    (testing "signing for CA with auth id from public key"
+      (let [extensions (create-ca-extensions issuer-pub subj-pub)
+            cert-w-exts (sign-certificate issuer issuer-priv serial not-before
+                                          not-after subject subj-pub extensions)
+            expected-ext {:oid authority-key-identifier-oid
+                          :critical false
+                          :value    {:issuer         nil
+                                     :key-identifier (pubkey-sha1 issuer-pub)
+                                     :serial-number  nil}}
+            actual-ext (get-extension cert-w-exts
+                                      authority-key-identifier-oid)]
+        (is (= actual-ext expected-ext))))
+
+    (testing "signing for CA with auth id from issuer and serial"
+      (let [extensions (create-ca-extensions issuer serial subj-pub)
+            cert-w-exts (sign-certificate issuer issuer-priv serial not-before
+                                          not-after subject subj-pub extensions)
+            expected-ext {:oid authority-key-identifier-oid
+                          :critical false
+                          :value    {:issuer         {:directory-name [issuer]}
+                                     :key-identifier nil
+                                     :serial-number  serial}}
+            actual-ext (get-extension cert-w-exts
+                                      authority-key-identifier-oid)]
         (is (= actual-ext expected-ext))))))
 
 (deftest certificate-test

--- a/test/puppetlabs/ssl_utils/testutils.clj
+++ b/test/puppetlabs/ssl_utils/testutils.clj
@@ -165,7 +165,7 @@
         not-after (generate-not-after-date)
         cert (sign-certificate issuer-name (get-private-key issuer-key-pair)
                                serial not-before not-after subject-name public-key
-                               (create-ca-extensions subject-name serial public-key))]
+                               (create-ca-extensions (get-public-key issuer-key-pair) public-key))]
     [cert key-pair]))
 
 (defn generate-cert-chain-with-crls


### PR DESCRIPTION
Previously, we only allowed generating CA cert extensions with serial
and issuer values for the authority key identifier. This is not valid
with some libraries (notably Ruby's openssl), which requires the auth
key id to include the key ID from the issuer's public key. This adds an
arity to the function that generates CA extensions, to allow generating
the more correct form.