### PR TITLE
(PE-32070) Update Java 11 security file for new BCFIPS

### DIFF
--- a/jdk11-fips-security
+++ b/jdk11-fips-security
@@ -61,7 +61,7 @@
 # List of providers and their preference orders (see above):
 #
 security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
-security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
+security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
 security.provider.3=SUN
 security.provider.4=SunRsaSign
 #security.provider.5=SunEC
@@ -319,7 +319,7 @@ security.overridePropertiesFile=true
 # Determines the default key and trust manager factory algorithms for
 # the javax.net.ssl package.
 #
-ssl.KeyManagerFactory.algorithm=SunX509
+ssl.KeyManagerFactory.algorithm=PKIX
 ssl.TrustManagerFactory.algorithm=PKIX
 
 #

--- a/jdk8-fips-security
+++ b/jdk8-fips-security
@@ -66,7 +66,7 @@
 # List of providers and their preference orders (see above):
 #
 security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
-security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
+security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
 security.provider.3=sun.security.provider.Sun
 security.provider.4=sun.security.rsa.SunRsaSign
 #security.provider.5=sun.security.ec.SunEC
@@ -288,7 +288,7 @@ security.overridePropertiesFile=true
 # Determines the default key and trust manager factory algorithms for
 # the javax.net.ssl package.
 #
-ssl.KeyManagerFactory.algorithm=SunX509
+ssl.KeyManagerFactory.algorithm=PKIX
 ssl.TrustManagerFactory.algorithm=PKIX
 
 #


### PR DESCRIPTION
There is an issue with the latest bc-fips version involving circular
provider loading, that can be fixed by using the full class name for the
BCJSSE FIPS provider, rather than relying on an alias. This commit
updates our java-security file for Java 11 to use the full name.

It also updates the key manager factory algorithm following a
recommendation from the BC maintainers.