### PR TITLE
(SERVER-3135) Update clj-parent to 4.9.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.6.22"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.9.2"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in


### PR DESCRIPTION
This update brings in Bouncy Castle 1.70, which has improved TLS 1.3
support.