### PR TITLE
(PE-36454) add support for adding attributes to csrs, fix issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## [unreleased]
+
+* add support for creating csrs with Attributes
+* remove use of deprecated routines in ExtensionUtils 
+
+# [3.5.0]

--- a/project.clj
+++ b/project.clj
@@ -60,6 +60,7 @@
                                        ["-Djava.security.properties==jdk8-fips-security"]
                                        (throw unsupported-ex))
                                    11 ["-Djava.security.properties==jdk11-fips-security"]
+                                   17 ["-Djava.security.properties==jdk17-fips-security"]
                                    (throw unsupported-ex)))
                     :resource-paths ["test-resources"]}
 

--- a/src/clojure/puppetlabs/ssl_utils/simple.clj
+++ b/src/clojure/puppetlabs/ssl_utils/simple.clj
@@ -117,7 +117,7 @@
    (let [validity (cert-validity-dates (* 5 60 60 24 365))
          extensions (if ca?
                       (ssl-utils/create-ca-extensions
-                        (:x509-name host-keys)
+                        (:x500-name host-keys)
                         serial
                         (:public-key host-keys))
                       (get options :extensions []))]
@@ -162,7 +162,7 @@
     serial :- schema/Int
     options :- SSLOptions
     ca? :- schema/Bool]
-   (let [cert-keys (gen-keys certname options) ]
+   (let [cert-keys (gen-keys certname options)]
      (assoc cert-keys :cert (gen-cert* cert-keys cert-keys serial options ca?)))))
 
 (schema/defn ^:always-validate gen-crl :- X509CRL

--- a/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
@@ -12,7 +12,6 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERUTF8String;
 import org.bouncycastle.asn1.misc.MiscObjectIdentifiers;
 import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
@@ -41,7 +40,6 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.InetAddress;
@@ -578,8 +576,8 @@ public class ExtensionsUtils {
             return CRLNumber.getInstance(data);
         } else {
             try {
-                // If the oid is unknown, attempt to parse it as a UTF8 String
-                return DERUTF8String.getInstance(data);
+                // If the oid is unknown, use the base primitive conversion
+                return ASN1Primitive.fromByteArray(data);
             } catch (Exception e) {
                 // This is required to maintain backwards compatibility with
                 // the erroneous method that Puppet previously used to sign
@@ -748,7 +746,7 @@ public class ExtensionsUtils {
                 .get(new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1));
 
         X509ExtensionUtils utils = new JcaX509ExtensionUtils(digCalc);
-        if (truncate == true) {
+        if (truncate) {
             return utils.createTruncatedSubjectKeyIdentifier(pubKeyInfo);
         }
         return utils.createSubjectKeyIdentifier(pubKeyInfo);
@@ -769,7 +767,7 @@ public class ExtensionsUtils {
             SubjectPublicKeyInfo.getInstance(pubKey.getEncoded());
 
         JcaX509ExtensionUtils utils = extensionUtils();
-        if (truncateKey == true) {
+        if (truncateKey) {
             byte[] shortKey = utils.createTruncatedSubjectKeyIdentifier(
                                       authPubKeyInfo).getKeyIdentifier();
             return new AuthorityKeyIdentifier(shortKey);

--- a/test/puppetlabs/ssl_utils/simple_test.clj
+++ b/test/puppetlabs/ssl_utils/simple_test.clj
@@ -13,7 +13,7 @@
 
 (deftest basic-ca-cert-crl-test
   (testing "Can generate a valid CA cert, cert, and CRL through simple API"
-    (let [ca-cert (simple/gen-self-signed-cert "ca" 1)
+    (let [ca-cert (simple/gen-self-signed-cert "ca" 1 {} true)
           cert (simple/gen-cert "foo.localdomain" ca-cert 2)
           crl (simple/gen-crl ca-cert)
           read-ca-cert (roundtrip-pem ssl-utils/cert->pem! ssl-utils/pem->cert (:cert ca-cert))


### PR DESCRIPTION
This adds support in the "simple" namespace for adding attributes to CSRs. It adds a test to demonstrate the behavior.

It also fixes several problems, including a typo in the "get-keys" function which was associating a name with the wrong key, as well as removing use of a deprecated conversion routine.

Some require organization was done as well.