### PR TITLE
(PE-36455) add support for reading attributes from certificate signing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 * add support for creating csrs with Attributes
 * remove use of deprecated routines in ExtensionUtils 
+* add support for reading attributes from Certificate Signing Requests
 
 # [3.5.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [unreleased]
 
+# [3.5.1]
 * add support for creating csrs with Attributes
 * remove use of deprecated routines in ExtensionUtils 
 * add support for reading attributes from Certificate Signing Requests


### PR DESCRIPTION

This adds a function to retrieve the attributes from Certificate Signing Requests. It adds tests to demonstrate the behaviors.