### PR TITLE
(maint) add ability to override CRL lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [unreleased]
 
+# [3.5.3]
+* add functions to SSLUtil to alter and retrieve CRL expiration time
+* update clj-parent to 5.6.4
+* update issue submission instructions in README.
+
 # [3.5.2]
 * remove infinite recursion from ASN1 conversion.
 * update clj-parent to 5.6.1 which includes bouncy castle 1.74

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ See [LICENSE](LICENSE) file.
 
 ## Support
 
-Please log tickets and issues at our [JIRA tracker](http://tickets.puppetlabs.com).
+Please log issues in the GitHub issue tracker.
 
 We use semantic version numbers for our releases, and recommend that users stay
 as up-to-date as possible by upgrading to patch releases and minor releases as

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 
   :min-lein-version "2.9.10"
 
-  :parent-project {:coords [puppetlabs/clj-parent "5.6.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.6.6"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in

--- a/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
+++ b/src/java/com/puppetlabs/ssl_utils/SSLUtils.java
@@ -107,6 +107,8 @@ public class SSLUtils {
     public static final String BOUNCYCASTLE_JSSE_PROVIDER = "BCJSSE";
     public static final String TLS_PROTOCOL = "TLS";
 
+    private static int crlLifetimeSeconds = 5 * 365 * 24 * 60 * 60;  // default to 5 years
+
     public static boolean isFIPS() {
         try {
             return getProviderClass().getCanonicalName().equals(FIPS_PROVIDER_CLASS);
@@ -358,7 +360,7 @@ public class SSLUtils {
     {
         DateTime now = DateTime.now();
         Date thisUpdate = now.toDate();
-        Date nextUpdate = now.plusYears(5).toDate();
+        Date nextUpdate = now.plusSeconds(crlLifetimeSeconds).toDate();
         return generateCRL(issuer, issuerPrivateKey, issuerPublicKey,
                            thisUpdate, nextUpdate, BigInteger.ZERO, null);
     }
@@ -1517,5 +1519,21 @@ public class SSLUtils {
     private static String getFingerprint(byte[] bytes, String digestAlgorithm) {
         MessageDigest digest = DigestUtils.getDigest(digestAlgorithm);
         return Hex.encodeHexString(digest.digest(bytes));
+    }
+
+    /***
+     * Get the number of seconds between when a CRL is generated and when it will expire.
+     * @return
+     */
+    public static int getCrlLifetimeSeconds() {
+        return crlLifetimeSeconds;
+    }
+
+    /***
+     * set the number of seconds after the generation time for a CRL before it will expire.
+     * @param seconds
+     */
+    public static void setCrlLifetimeSeconds(int seconds) {
+        crlLifetimeSeconds = seconds;
     }
 }


### PR DESCRIPTION
This adds a backdoor to allow the CRL 5 year expiration to be overridden with a value in seconds.